### PR TITLE
feat: add AWS ECR support for Helm chart registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,31 @@
 
 # action-helm-build
 
-A GitHub Action that packages and pushes Helm charts to GCP Artifact Registry. It simplifies the CI/CD workflow by automating the process of versioning, packaging, and pushing Helm charts.
+A GitHub Action that packages and pushes Helm charts to AWS ECR and GCP Artifact Registry. It simplifies the CI/CD workflow by automating the process of versioning, packaging, and pushing Helm charts.
 
 ## Features
 
+- Multi-registry support: AWS ECR, GCP Artifact Registry
 - Automatic chart versioning from `TAG_VERSION`
 - Helm chart packaging using `helm package`
-- OCI registry push to GCP Artifact Registry
-- Workload Identity Federation support
+- OCI registry push
+- Workload Identity Federation support (GCP)
+- IAM role assumption support (AWS)
 
 ## Quick Start
 
 ```yaml
-- uses: google-github-actions/auth@v2
+- name: Build & Push Helm Chart (AWS)
+  uses: martoc/action-helm-build@v0
   with:
-    workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-    service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+    registry: aws
+    region: us-east-2
+    repository_name: helm-charts
+    aws_account_id: "123456789012"
+```
 
-- name: Build & Push Helm Chart
+```yaml
+- name: Build & Push Helm Chart (GCP)
   uses: martoc/action-helm-build@v0
   with:
     registry: gcp
@@ -37,9 +44,10 @@ A GitHub Action that packages and pushes Helm charts to GCP Artifact Registry. I
 
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
-| `registry` | Registry to push to (`gcp`) | No | `docker.io` |
-| `region` | GCP region | No | `""` |
+| `registry` | Registry to push to (`gcp`, `aws`) | No | `docker.io` |
+| `region` | GCP or AWS region | No | `""` |
 | `repository_name` | Repository name | No | `""` |
+| `aws_account_id` | AWS Account ID | No | `""` |
 | `gcp_project_id` | Google Cloud Project ID | No | `""` |
 
 ## Environment Variables

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ description: |
 author: martoc
 inputs:
   registry:
-    description: 'Registry to push the container to (default: docker.io) valid values: gcp'
+    description: 'Registry to push the Helm chart to (default: docker.io) valid values: gcp, aws'
     required: false
     default: 'docker.io'
   region:
@@ -61,6 +61,10 @@ runs:
           GCP_PROJECT_ID="${{ inputs.gcp_project_id }}"
         fi
 
+        if [ -n "${{ inputs.aws_account_id }}" ]; then
+          ACCOUNT_ID="${{ inputs.aws_account_id }}"
+        fi
+
         if [ "${REGISTRY}" = "gcp" ]; then
           if [ -z "${REGION}" ]; then
             echo "REGION must be set when using 'gcp' registry"
@@ -75,9 +79,30 @@ runs:
             exit 1
           fi
           gcloud auth print-access-token | helm registry login -u oauth2accesstoken --password-stdin https://${REGION}-docker.pkg.dev
-          REGISTRY_URL="oci://${REGION}-docker.pkg.dev"
+          REGISTRY_URL="oci://${REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${REPOSITORY_NAME}"
+        elif [ "${REGISTRY}" = "aws" ]; then
+          if [ -z "${REGION}" ]; then
+            echo "REGION must be set when using 'aws' registry"
+            exit 1
+          fi
+          if [ -z "${ACCOUNT_ID}" ]; then
+            echo "ACCOUNT_ID must be set when using 'aws' registry, use aws_account_id input or ACCOUNT_ID envar"
+            exit 1
+          fi
+          if ! echo "${ACCOUNT_ID}" | grep -qE '^[0-9]{12}$'; then
+            echo "ACCOUNT_ID must be a 12-digit AWS account ID, got: ${ACCOUNT_ID}"
+            exit 1
+          fi
+          if [ -z "${REPOSITORY_NAME}" ]; then
+            echo "REPOSITORY_NAME must be set when using 'aws' registry"
+            exit 1
+          fi
+          aws ecr get-login-password --region ${REGION} | helm registry login --username AWS --password-stdin ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com
+          REGISTRY_URL="oci://${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/${REPOSITORY_NAME}"
         else
-          echo "Only GCP registry is supported"
+          echo "Unknown registry: ${REGISTRY}. Valid values are:"
+          echo "  - gcp"
+          echo "  - aws"
           exit 1
         fi
-        helm push ${NAME}-${TAG_VERSION}.tgz ${REGISTRY_URL}/${GCP_PROJECT_ID}/${REPOSITORY_NAME}
+        helm push ${NAME}-${TAG_VERSION}.tgz ${REGISTRY_URL}

--- a/action.yml
+++ b/action.yml
@@ -5,29 +5,29 @@ description: |
 author: martoc
 inputs:
   registry:
-    description: 'Registry to push the Helm chart to (default: docker.io) valid values: gcp, aws'
+    description: "Registry to push the Helm chart to (default: docker.io) valid values: gcp, aws"
     required: false
-    default: 'docker.io'
+    default: "docker.io"
   region:
-    description: 'Region to push the container to valid values: google cloud or aws regions'
+    description: "Region to push the container to valid values: google cloud or aws regions"
     required: false
-    default: ''
+    default: ""
   repository_name:
-    description: 'Repository Name'
+    description: "Repository Name"
     required: false
-    default: ''
+    default: ""
   aws_account_id:
-    description: 'AWS Account ID'
+    description: "AWS Account ID"
     required: false
-    default: ''
+    default: ""
   gcp_project_id:
-    description: 'Google Cloud Project ID'
+    description: "Google Cloud Project ID"
     required: false
-    default: ''
+    default: ""
 runs:
   using: "composite"
   steps:
-    - name: 'Set up Cloud SDK'
+    - name: "Set up Cloud SDK"
       uses: google-github-actions/setup-gcloud@v2
       with:
         version: 499.0.0

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This GitHub Action is designed to package and push Helm charts to Google Cloud Artifact Registry.
+This GitHub Action is designed to package and push Helm charts to AWS Elastic Container Registry (ECR) and Google Cloud Artifact Registry.
 It simplifies the CI/CD workflow by automating the process of versioning, packaging,
 and pushing Helm charts.
 
@@ -11,6 +11,10 @@ and pushing Helm charts.
 Secrets Configuration
 
 Before using this action, ensure that you have the following secrets configured in your GitHub repository:
+
+### AWS ECR
+
+* **AWS_ROLE_TO_ASSUME:** The ARN of the AWS role to assume for authentication.
 
 ### GCP Artifact Registry
 
@@ -23,10 +27,10 @@ Before using this action, ensure that you have the following secrets configured 
 
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
-| `registry` | Registry to push the Helm chart to. Valid values: `gcp` | No | `docker.io` |
-| `region` | Region to push the Helm chart to. Valid for GCP regions | No | `""` |
+| `registry` | Registry to push the Helm chart to. Valid values: `gcp`, `aws` | No | `docker.io` |
+| `region` | Region to push the Helm chart to. Valid for GCP or AWS regions | No | `""` |
 | `repository_name` | Repository name | No | `""` |
-| `aws_account_id` | AWS Account ID (reserved for future use) | No | `""` |
+| `aws_account_id` | AWS Account ID | No | `""` |
 | `gcp_project_id` | Google Cloud Project ID | No | `""` |
 
 ### Environment Variables
@@ -40,7 +44,7 @@ The following environment variables can be used to customize the build:
 ## Example
 
 Here are examples of how to use this GitHub Action to package and push Helm
-charts to GCP Artifact Registry.
+charts to AWS ECR and GCP Artifact Registry.
 
 ```yaml
 name: Integration Tests
@@ -54,6 +58,34 @@ on:
       - main
 
 jobs:
+  aws:
+    permissions:
+      contents: write
+      id-token: write
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 50
+          fetch-tags: true
+      - name: Tag
+        uses: martoc/action-tag@v0
+        with:
+          skip-push: true
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: github-actions
+          aws-region: us-east-2
+      - name: Build & Push Helm Chart
+        uses: martoc/action-helm-build@v0
+        with:
+          registry: aws
+          region: us-east-2
+          repository_name: helm-charts
+          aws_account_id: "123456789012"
+
   gcp:
     permissions:
       contents: write
@@ -82,6 +114,14 @@ jobs:
 ```
 
 ## Registry-Specific Requirements
+
+### AWS ECR
+
+* `registry` input must be set to `aws`
+* `region` input is required
+* `repository_name` input is required
+* `aws_account_id` input is required
+* AWS credentials must be configured (e.g., using `aws-actions/configure-aws-credentials`)
 
 ### GCP Artifact Registry
 


### PR DESCRIPTION
## Summary

- Add AWS ECR as a supported registry alongside GCP Artifact Registry
- Implement ECR authentication via aws ecr get-login-password piped to helm registry login
- Add input validation for AWS account ID (12-digit format), region, and repository name
- Update README.md and USAGE.md with AWS ECR examples and requirements

## Test plan

- [ ] Verify Helm chart push to AWS ECR with valid credentials
- [ ] Verify validation errors for missing region, account ID, and repository name
- [ ] Verify 12-digit account ID format validation
- [ ] Verify GCP registry flow remains unchanged