### PR TITLE
fix: upgrade aws-actions/configure-aws-credentials to v6 for Node 24

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -73,7 +73,7 @@ jobs:
         with:
           skip-push: true
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: github-actions


### PR DESCRIPTION
## Summary

- Bump `aws-actions/configure-aws-credentials` v4 → v6 in `docs/USAGE.md` so the usage example no longer references an action running on Node.js 20.

## Why

GitHub Actions has deprecated Node.js 20 (see [deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). From 2 June 2026, affected actions will be forced onto Node.js 24; Node.js 20 is removed from the runner on 16 September 2026.

## Test plan

- [ ] CI checks pass
